### PR TITLE
Some fixes and improvements (retake)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macOS-latest ]
+        os: [ ubuntu-latest, windows-latest, macOS-11 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macOS-11 ]
+        #os: [ ubuntu-latest, windows-latest, macOS-11 ]
+        os: [ ubuntu-latest, macOS-11 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macOS-latest ]
+        os: [ ubuntu-latest, windows-latest, macOS-11 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
 
     runs-on: ${{matrix.os}}
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-11 ]
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,10 @@ korge {
   targetJs()
   targetIos()
   targetAndroidIndirect()
+  targetDesktop()
 
   serializationJson()
+  useNewMemoryModel = true
 }
 
 kotlin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.kotlin.dsl.korge
+
 plugins {
   id("com.soywiz.korge")
 }
@@ -19,5 +21,15 @@ kotlin {
       languageSettings.useExperimentalAnnotation("kotlin.RequiresOptIn")
       languageSettings.useExperimentalAnnotation("kotlin.ExperimentalUnsignedTypes")
     }
+  }
+}
+
+tasks {
+  val runJvm by getting(com.soywiz.korge.gradle.targets.jvm.KorgeJavaExec::class)
+  create("runJvmNativeImage", com.soywiz.korge.gradle.targets.jvm.KorgeJavaExec::class) {
+    group = com.soywiz.korge.gradle.targets.GROUP_KORGE_RUN
+    dependsOn("jvmMainClasses")
+    mainClass.set(runJvm.mainClass)
+    environment("USE_NATIVE_IMAGE", "true")
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-korgePluginVersion=2.4.2
+korgePluginVersion=2.4.8
 kotlin.mpp.stability.nowarn=true
 org.gradle.jvmargs=-Xmx12g
 kotlin.incremental.js.klib=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 korgePluginVersion=2.4.8
 kotlin.mpp.stability.nowarn=true
-org.gradle.jvmargs=-Xmx12g
+org.gradle.jvmargs=-Xmx4g
 kotlin.incremental.js.klib=false
 
 korge.enable.android.indirect=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/commonMain/kotlin/main.kt
+++ b/src/commonMain/kotlin/main.kt
@@ -18,7 +18,9 @@ import com.soywiz.korma.geom.Anchor
 import com.soywiz.korma.geom.ScaleMode
 import org.jetbrains.projector.client.common.misc.ParamsProvider
 import org.jetbrains.projector.client.korge.Application
+import kotlin.native.concurrent.*
 
+@ThreadLocal
 lateinit var mainStage: Stage
     private set
 

--- a/src/commonMain/kotlin/main.kt
+++ b/src/commonMain/kotlin/main.kt
@@ -13,6 +13,7 @@ import com.soywiz.korge.view.centerOnStage
 import com.soywiz.korge.view.solidRect
 import com.soywiz.korim.color.Colors
 import com.soywiz.korim.color.RGBA
+import com.soywiz.korim.format.*
 import com.soywiz.korma.geom.Anchor
 import com.soywiz.korma.geom.ScaleMode
 import org.jetbrains.projector.client.common.misc.ParamsProvider
@@ -25,6 +26,8 @@ suspend fun main() = Korge(
     width = 800, height = 600,
     title = "korjector",
 ) {
+    RegisteredImageFormats.register(PNG)
+
     Logger.defaultLevel = Logger.Level.DEBUG
     mainStage = stage
 

--- a/src/commonMain/kotlin/org/jetbrains/projector/client/common/canvas/CanvasFactory.kt
+++ b/src/commonMain/kotlin/org/jetbrains/projector/client/common/canvas/CanvasFactory.kt
@@ -1,16 +1,18 @@
 package org.jetbrains.projector.client.common.canvas
 
 import com.soywiz.korge.view.Image
-import com.soywiz.korim.bitmap.Bitmap32
-import com.soywiz.korim.color.Colors
+import com.soywiz.korim.bitmap.*
 import com.soywiz.korim.format.readBitmap
 import com.soywiz.korio.async.launch
+import com.soywiz.korio.lang.*
 import com.soywiz.korio.stream.openAsync
 import com.soywiz.krypto.encoding.fromBase64
 import mainStage
 
+val USE_NATIVE_IMAGE = Environment["USE_NATIVE_IMAGE"] == "true"
+
 object CanvasFactory {
-  fun create(): Canvas = KorgeCanvas(Image(Bitmap32(42, 42, Colors.MAGENTA)))
+  fun create(): Canvas = KorgeCanvas(Image(NativeImageOrBitmap32(42, 42, USE_NATIVE_IMAGE)))
   fun createImageSource(pngBase64: String, onLoad: (Canvas.ImageSource) -> Unit) {
     mainStage.launch {
       val bmp = pngBase64.fromBase64().openAsync().readBitmap()
@@ -19,6 +21,6 @@ object CanvasFactory {
   }
 
   fun createEmptyImageSource(onLoad: (Canvas.ImageSource) -> Unit) {
-    onLoad(KorgeCanvas.DomImageSource(Bitmap32(20, 20, Colors.MAGENTA)))
+    onLoad(KorgeCanvas.DomImageSource(NativeImageOrBitmap32(20, 20, USE_NATIVE_IMAGE)))
   }
 }

--- a/src/commonMain/kotlin/org/jetbrains/projector/client/common/canvas/KorgeCanvas.kt
+++ b/src/commonMain/kotlin/org/jetbrains/projector/client/common/canvas/KorgeCanvas.kt
@@ -13,13 +13,13 @@ class KorgeCanvas(val myCanvas: Image) : Canvas {
   override var width: Int
     get() = myCanvas.width.toInt()
     set(value) {
-      myCanvas.bitmapSrc = Bitmap32(value, height, Colors.TRANSPARENT_BLACK).slice()
+      myCanvas.bitmapSrc = NativeImageOrBitmap32(value, height, USE_NATIVE_IMAGE).slice()
     }
 
   override var height: Int
     get() = myCanvas.height.toInt()
     set(value) {
-      myCanvas.bitmapSrc = Bitmap32(width, value, Colors.TRANSPARENT_BLACK).slice()
+      myCanvas.bitmapSrc = NativeImageOrBitmap32(width, value, USE_NATIVE_IMAGE).slice()
     }
 
   override var fontVariantLigatures: String

--- a/src/commonMain/kotlin/org/jetbrains/projector/client/common/misc/ParamsProvider.kt
+++ b/src/commonMain/kotlin/org/jetbrains/projector/client/common/misc/ParamsProvider.kt
@@ -1,7 +1,9 @@
 package org.jetbrains.projector.client.common.misc
 
 import com.soywiz.korio.net.URL
+import kotlin.native.concurrent.*
 
+@ThreadLocal
 object ParamsProvider {
 
   val SYSTEM_SCALING_RATIO

--- a/src/commonMain/kotlin/org/jetbrains/projector/client/common/misc/TimeStamp.kt
+++ b/src/commonMain/kotlin/org/jetbrains/projector/client/common/misc/TimeStamp.kt
@@ -3,5 +3,5 @@ package org.jetbrains.projector.client.common.misc
 import com.soywiz.klock.DateTime
 
 object TimeStamp {
-  val current: Double = DateTime.nowUnix()
+  val current: Double get() = DateTime.nowUnix()
 }

--- a/src/commonMain/kotlin/org/jetbrains/projector/client/korge/misc/ClientStats.kt
+++ b/src/commonMain/kotlin/org/jetbrains/projector/client/korge/misc/ClientStats.kt
@@ -5,7 +5,9 @@ import org.jetbrains.projector.client.common.misc.TimeStamp
 import org.jetbrains.projector.common.statistics.Average
 import org.jetbrains.projector.common.statistics.Rate
 import org.jetbrains.projector.common.statistics.RoundingStrategy
+import kotlin.native.concurrent.ThreadLocal
 
+@ThreadLocal
 object ClientStats {
 
   private val logger = Logger<ClientStats>()

--- a/src/commonMain/kotlin/org/jetbrains/projector/client/korge/misc/FontFaceAppender.kt
+++ b/src/commonMain/kotlin/org/jetbrains/projector/client/korge/misc/FontFaceAppender.kt
@@ -5,7 +5,9 @@ import com.soywiz.korim.font.TtfFont
 import com.soywiz.krypto.encoding.fromBase64
 import org.jetbrains.projector.client.common.canvas.Extensions.toFontFaceName
 import org.jetbrains.projector.common.protocol.data.TtfFontData
+import kotlin.native.concurrent.ThreadLocal
 
+@ThreadLocal
 object FontFaceAppender {
 
   private var loadedFonts = 0

--- a/src/commonMain/kotlin/org/jetbrains/projector/client/korge/state/ClientState.kt
+++ b/src/commonMain/kotlin/org/jetbrains/projector/client/korge/state/ClientState.kt
@@ -467,7 +467,7 @@ sealed class ClientState {
 
           if (drawEventCount > 0) {
             logger.debug {
-              "Timestamp is ${roundToTwoDecimals(processTimestamp)}:\t" +
+              "Timestamp is ${processTimestamp.toLong()}:\t" +
                       "draw events count: $drawEventCount,\t" +
                       "decompressing: ${roundToTwoDecimals(decompressingTimeMs)} ms,\t\t" +
                       "decoding: ${roundToTwoDecimals(decodingTimeMs)} ms,\t\t" +

--- a/src/commonMain/kotlin/org/jetbrains/projector/client/korge/state/ClientState.kt
+++ b/src/commonMain/kotlin/org/jetbrains/projector/client/korge/state/ClientState.kt
@@ -600,7 +600,7 @@ sealed class ClientState {
 
     private suspend fun createWebSocketConnection(url: String, stateMachine: ClientStateMachine): WebSocketClient? {
       return try {
-        WebSocketClient(url).apply {
+        WebSocketClient(url) {
           onOpen {
             stateMachine.fire(ClientAction.WebSocket.Open(openingTimeStamp = TimeStamp.current.roundToInt()))
           }

--- a/src/commonMain/kotlin/org/jetbrains/projector/client/korge/state/MessagingPolicy.kt
+++ b/src/commonMain/kotlin/org/jetbrains/projector/client/korge/state/MessagingPolicy.kt
@@ -3,6 +3,7 @@ package org.jetbrains.projector.client.korge.state
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import mainStage
 
 sealed class MessagingPolicy(
   protected val isFlushNeeded: () -> Boolean,
@@ -39,14 +40,12 @@ sealed class MessagingPolicy(
   class Buffered(private val timeout: Int, isFlushNeeded: () -> Boolean, flush: () -> Unit) :
     MessagingPolicy(isFlushNeeded, flush) {
 
-    private val scope = GlobalScope
-
     override fun onHandshakeFinished() {
       flush()
     }
 
     private fun scheduleFlushIfNeeded() {
-      scope.launch {
+      mainStage.launch {
         delay(timeout.toLong())
         flushIfNeeded()
       }

--- a/src/commonMain/kotlin/org/jetbrains/projector/client/korge/state/ProjectorUI.kt
+++ b/src/commonMain/kotlin/org/jetbrains/projector/client/korge/state/ProjectorUI.kt
@@ -1,12 +1,14 @@
 package org.jetbrains.projector.client.korge.state
 
 import org.jetbrains.projector.common.protocol.toClient.ServerWindowColorsEvent
+import kotlin.native.concurrent.ThreadLocal
 
 interface LafListener {
   fun lookAndFeelChanged()
 }
 
 // Name of this class was chosen based on JBUI class.
+@ThreadLocal
 object ProjectorUI {
   var windowHeaderActiveBackgroundArgb = 0xFFE6E6E6.toInt()
     private set

--- a/src/commonMain/kotlin/org/jetbrains/projector/client/korge/window/OnScreenMessenger.kt
+++ b/src/commonMain/kotlin/org/jetbrains/projector/client/korge/window/OnScreenMessenger.kt
@@ -11,7 +11,9 @@ import org.jetbrains.projector.client.common.misc.ParamsProvider
 import org.jetbrains.projector.client.korge.state.LafListener
 import org.jetbrains.projector.client.korge.state.ProjectorUI
 import org.jetbrains.projector.common.protocol.data.CommonRectangle
+import kotlin.native.concurrent.*
 
+@ThreadLocal
 object OnScreenMessenger : LafListener {
 
   private val logger = Logger<OnScreenMessenger>()

--- a/src/commonMain/kotlin/org/jetbrains/projector/client/korge/window/Window.kt
+++ b/src/commonMain/kotlin/org/jetbrains/projector/client/korge/window/Window.kt
@@ -5,11 +5,11 @@ import com.soywiz.korge.input.cursor
 import com.soywiz.korge.view.image
 import com.soywiz.korge.view.xy
 import com.soywiz.korgw.GameWindow
-import com.soywiz.korim.bitmap.Bitmap32
-import com.soywiz.korim.color.Colors
+import com.soywiz.korim.bitmap.*
 import mainStage
 import org.jetbrains.projector.client.common.DrawEvent
 import org.jetbrains.projector.client.common.SingleRenderingSurfaceProcessor
+import org.jetbrains.projector.client.common.canvas.*
 import org.jetbrains.projector.client.common.canvas.buffering.createRenderingSurface
 import org.jetbrains.projector.client.common.misc.ImageCacher
 import org.jetbrains.projector.client.common.misc.ParamsProvider
@@ -183,7 +183,7 @@ class Window(windowData: WindowData, private val stateMachine: ClientStateMachin
     stateMachine.fire(ClientAction.AddEvent(ClientWindowCloseEvent(id)))
   }
 
-  private fun createCanvas() = mainStage.image(Bitmap32(42, 42, Colors.TRANSPARENT_BLACK)).apply {
+  private fun createCanvas() = mainStage.image(NativeImageOrBitmap32(42, 42, USE_NATIVE_IMAGE)).apply {
     visible = isShowing
   }
 

--- a/src/commonMain/kotlin/org/jetbrains/projector/client/korge/window/WindowHeader.kt
+++ b/src/commonMain/kotlin/org/jetbrains/projector/client/korge/window/WindowHeader.kt
@@ -5,16 +5,13 @@ import com.soywiz.korge.input.onOut
 import com.soywiz.korge.view.Container
 import com.soywiz.korge.view.image
 import com.soywiz.korge.view.xy
-import com.soywiz.korim.bitmap.Bitmap
-import com.soywiz.korim.bitmap.Bitmap32
-import com.soywiz.korim.color.Colors
+import com.soywiz.korim.bitmap.*
 import com.soywiz.korim.font.DefaultTtfFont
 import com.soywiz.korim.format.SVG
 import com.soywiz.korim.format.readBitmap
 import com.soywiz.korio.file.std.resourcesVfs
 import com.soywiz.korma.geom.IPoint
-import org.jetbrains.projector.client.common.canvas.KorgeCanvas
-import org.jetbrains.projector.client.common.canvas.PaintColor
+import org.jetbrains.projector.client.common.canvas.*
 import org.jetbrains.projector.client.common.canvas.buffering.createRenderingSurface
 import org.jetbrains.projector.client.common.misc.ParamsProvider
 import org.jetbrains.projector.client.korge.state.LafListener
@@ -37,7 +34,7 @@ class WindowHeader(parent: Container, var title: String? = null) : DragEventsInt
 
   private var closeIcon = closeIconNormal
 
-  private val canvas = parent.image(Bitmap32(42, 42, Colors.TRANSPARENT_BLACK))
+  private val canvas = parent.image(NativeImageOrBitmap32(42, 42, USE_NATIVE_IMAGE))
   private val headerRenderingSurface = createRenderingSurface(canvas)
 
   private var dragStarted = false

--- a/src/commonMain/kotlin/org/jetbrains/projector/client/korge/window/WindowHeader.kt
+++ b/src/commonMain/kotlin/org/jetbrains/projector/client/korge/window/WindowHeader.kt
@@ -19,9 +19,11 @@ import org.jetbrains.projector.client.korge.state.ProjectorUI
 import org.jetbrains.projector.common.protocol.data.CommonRectangle
 import org.jetbrains.projector.common.protocol.data.Point
 import kotlin.math.roundToInt
+import kotlin.native.concurrent.*
 
 class WindowHeader(parent: Container, var title: String? = null) : DragEventsInterceptor, LafListener {
 
+  @ThreadLocal
   companion object {
     lateinit var closeIconNormal: Bitmap
     lateinit var closeIconHover: Bitmap


### PR DESCRIPTION
This is a small cleanup on the changes I did.

Included changes:

* Fixes the problem where the JVM target hanged
* Fixes a timestamp issue
* Bumps korge and gradle
* Supports rendering by using NativeImage (toggleable via environment variable + gradle task)
* PNG was not available and some image rendering didn't work
* JS WebSocket didn't work because the open event was triggered before registration
* Reduced memory usage assigned to the JVM to avoid OOM on CI
* Removed fail-fast on CI so if one platform fails, the other ones continue
* ThreadLocal additions to support K/N

Hopefully this time it will work: https://github.com/soywiz/korjector/actions